### PR TITLE
move sidenav after main section for mobile

### DIFF
--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -4,6 +4,7 @@
   padding: 0;
   display: grid;
   grid-gap: 16px;
+  margin-left: 0;
 }
 
 .cards:not(.ein) > ul {
@@ -31,6 +32,8 @@
   width: 100%;
   object-fit: cover;
 }
+
+
 
 .cards h2 {
   font-size: 20px;

--- a/blocks/sidenav/sidenav.css
+++ b/blocks/sidenav/sidenav.css
@@ -1,5 +1,4 @@
 .sidenav {
-  padding: 2rem;
   font-size: var(--body-font-size-s);
 }
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -32,11 +32,11 @@ function buildHeroBlock(main) {
 }
 
 function buildSidebar(main) {
-  main.classList.add('main-content');
+  main.querySelectorAll(':scope > div').forEach((section) => section.classList.add('main-content'));
   const sidenav = document.createElement('div');
-  sidenav.classList.add('sidenav');
+  sidenav.classList.add('side-content');
   sidenav.append(buildBlock('sidenav', ' '));
-  main.prepend(sidenav);
+  main.append(sidenav);
 }
 
 /**

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -40,6 +40,7 @@
 
   /* nav height */
   --nav-height: 35px;
+  --header-height: 170px;
 
 }
 
@@ -70,8 +71,9 @@ body.appear {
 }
 
 header {
-  height: var(--nav-height);
+  height: var(--header-height);
 }
+
 
 h1, h2, h3,
 h4, h5, h6 {
@@ -235,13 +237,45 @@ main img {
   width: 100%;
 }
 
-main .section {
-  padding: 64px 16px;
+main {
+  display: block;
+  padding: 0 2%;
+  margin-top: 30px;
+}
+
+/* clearfix main */
+main::after {
+  content: " "; 
+  display: table;
+  clear: both;
+}
+
+main .side-content {
+  width: 100%;
+  float: left;
+}
+
+main .main-content {
+  width: 100%;
+  float: right;
 }
 
 @media (min-width: 600px) {
-  main .section {
-    padding: 64px 32px;
+  main {
+    display: block;
+    padding: 0;
+    margin: 30px auto;
+    width: 1170px;
+  }
+
+  main .side-content {
+    width: 27%;
+    float: left;
+  }
+
+  main .main-content {
+    width: 70%;
+    float: right;
   }
 }
 
@@ -257,8 +291,6 @@ main .section.highlight {
   background-color: var(--highlight-background-color);
 }
 
-main.main-content {
-  display: grid;
-  grid-template-columns: 1fr 2fr;
-  margin: 199px 164px;
-}
+
+
+


### PR DESCRIPTION
Use a responsive layout, similar to the original site, based on flowing elements.

the side-content will flow: left and the main-content will flow right.

Fix https://github.com/mtilburgadobe/turnerbund-wyhlen/issues/19


Test URLs:
- Before: https://main--turnerbund-wyhlen--mtilburgadobe.hlx.page/
- After: https://fix-mobile2--turnerbund-wyhlen--mtilburgadobe.hlx.page/
