### PR TITLE
Improve PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,6 @@
 Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):
 
 Fix #<gh-issue-id>
-
 Test URLs:
-- Before: https://main--<repo>--<owner>.hlx.page/
-- After: https://<branch>--<repo>--<owner>.hlx.page/
+- Before: https://main--turnerbund-wyhlen--mtilburgadobe.hlx.page/
+- After: https://<branch>--turnerbund-wyhlen--mtilburgadobe.hlx.page/


### PR DESCRIPTION
Simplifies creating the PR by prefilling the info we already have on the repo.

Test URLs:
- Before: https://main--turnerbund-wyhlen--mtilburgadobe.hlx.page/
- After: https://improve-pr-template--turnerbund-wyhlen--mtilburgadobe.hlx.page/
